### PR TITLE
Add Cosmos-SDK Crypo codecs

### DIFF
--- a/oracle/client/codec.go
+++ b/oracle/client/codec.go
@@ -3,9 +3,10 @@ package client
 import (
 	kiiparams "github.com/kiichain/kiichain/v3/app/params"
 
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	cryptocodec "github.com/cosmos/evm/crypto/codec"
+	evmcryptocodec "github.com/cosmos/evm/crypto/codec"
 )
 
 var encodingConfig kiiparams.EncodingConfig
@@ -16,6 +17,7 @@ func init() {
 	// Register cosmos-sdk interfaces
 	authtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 
-	// Register the pubkey EVM interface
+	// Register the pubkey for EVM and Cosmos interface
+	evmcryptocodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	cryptocodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 }


### PR DESCRIPTION
# Description

This fixes an issue when reading keys of type `/cosmos.crypto.secp256k1.PubKey`:
- This makes both EVM and cosmos crypo codecs available

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tested locally