### PR TITLE
Remove Cosmos SDK from version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BUILD_TARGETS := build install
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
 $(BUILD_TARGETS): check_version go.sum $(BUILDDIR)/
-	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
+	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./cmd/price-feeder
 
 $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/

--- a/cmd/price-feeder/cmd/version.go
+++ b/cmd/price-feeder/cmd/version.go
@@ -3,18 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"runtime"
 
-	"github.com/sirkon/goproxy/gomod"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
 const (
 	flagFormat = "format"
-
-	pathCosmosSDK = "github.com/cosmos/cosmos-sdk"
 )
 
 var (
@@ -31,7 +27,6 @@ var (
 type versionInfo struct {
 	Version string `json:"version" yaml:"version"`
 	Commit  string `json:"commit" yaml:"commit"`
-	SDK     string `json:"sdk" yaml:"sdk"`
 	Go      string `json:"go" yaml:"go"`
 }
 
@@ -50,28 +45,17 @@ func CmdgetVersion() *cobra.Command {
 
 // getVersionCmdHandler gets the project and go version from the go.mod file
 func getVersionCmdHandler(cmd *cobra.Command, args []string) error {
-	// get go.mod file
-	modBz, err := os.ReadFile("go.mod")
-	if err != nil {
-		return err
-	}
-
-	mod, err := gomod.Parse("go.mod", modBz)
-	if err != nil {
-		return err
-	}
-
 	// set version info
 	verInfo := versionInfo{
 		Version: Version,
 		Commit:  Commit,
-		SDK:     mod.Require[pathCosmosSDK],
 		Go:      fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 	}
 
 	var bz []byte
 
 	// print on the selected log format
+	var err error
 	switch versionFormat {
 	case "json":
 		bz, err = json.Marshal(verInfo)


### PR DESCRIPTION
# Description

This fixes an issue for a user on Discord:
- When executing the binary tries to load the Cosmos-SDK version but it fails when loading the go.mod
- This makes the binary not fully load when executed from a path with no go.mod
- To fix we can just remove the Cosmos-SDK from version load

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tested locally
