### PR TITLE
Fix broken fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 This is the Kiichain version of the incredible work of SEI on the price feeder module. The original implementation is available at [SEI's price-feeder](https://github.com/sei-protocol/sei-chain/tree/main/oracle/price-feeder).
 
+Further documentation for the project can be found at [Running the Price feeder](https://docs.kiiglobal.io/docs/validate-the-network/run-a-validator-full-node/running-the-price-feeder).
+
 # Setup
 
 If a cluster is running Oracle price-feeder, your validator is also required to run a price feeder or your validator will be jailed for missing votes.
+
+## Bootstrap
+
+We highly recommend bootstrapping the price-feeder installation using our installer:
+
+```bash
+wget https://raw.githubusercontent.com/KiiChain/testnets/main/testnet_oro/run_price_feeder.sh
+chmod +x run_price_feeder.sh
+./run_price_feeder.sh
+```
 
 ## Create an account for Oracle Price Feeder Delegate
 
@@ -90,6 +102,7 @@ price_feeder start oracle/price_feeder/config.toml
 
 A HTTP server can be enabled on the price feeder.
 The server will expose the following endpoints:
+
 - `/healthz`: A simple health check endpoint that returns a 200 OK response.
 - `/prices`: Returns the current prices fetched from the oracle's set of exchange rate providers.
 - `/metrics`: Returns the current metrics collected by the price feeder, including prices and their timestamps.

--- a/config.example.toml
+++ b/config.example.toml
@@ -33,7 +33,7 @@ gas_adjustment = 1.5
 # Gas prices are specified in the format "<amount><denom>", e.g., "400000000000akii"
 gas_prices = "400000000000akii"
 # Gas limit is the maximum amount of gas that can be used for a transaction
-gas_limit = 2000000
+gas_limit = 200000
 
 #######################################################
 ###                   Account                       ###

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,8 +30,8 @@ allowed_origins = ["*"]
 [gas]
 # Gas adjustment is a multiplier applied to the gas estimate
 gas_adjustment = 1.5
-# Gas prices are specified in the format "<amount><denom>", e.g., "500000akii"
-gas_prices = "500000akii"
+# Gas prices are specified in the format "<amount><denom>", e.g., "400000000000akii"
+gas_prices = "400000000000akii"
 # Gas limit is the maximum amount of gas that can be used for a transaction
 gas_limit = 2000000
 

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -318,6 +318,7 @@ func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
 		WithTxConfig(clientCtx.TxConfig).
 		WithGasAdjustment(oc.GasAdjustment).
 		WithGasPrices(oc.GasPrices).
+		WithGas(0).
 		WithKeybase(clientCtx.Keyring).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 		WithSimulateAndExecute(true)

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -14,6 +14,8 @@ import (
 	tmrpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	tmjsonclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 
+	"cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -203,6 +205,9 @@ func (oc OracleClient) BroadcastTx(
 	if err != nil {
 		return nil, err
 	}
+
+	// Calculate the fee for the TX
+	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("akii", math.NewIntFromUint64(80000000000000000))))
 
 	txBuilder.SetGasLimit(oc.GasLimit)
 

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -207,7 +207,8 @@ func (oc OracleClient) BroadcastTx(
 	}
 
 	// Calculate the fee for the TX and set the gas limit
-	txf.GasPrices().MulDec(math.LegacyNewDec(int64(oc.GasLimit)))
+	fees, _ := txf.GasPrices().MulDec(math.LegacyNewDec(int64(oc.GasLimit))).TruncateDecimal()
+	txBuilder.SetFeeAmount(fees)
 	txBuilder.SetGasLimit(oc.GasLimit)
 
 	// Sign the transaction

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -224,7 +224,7 @@ func (oc OracleClient) BroadcastTx(
 	}
 
 	// Log the transaction details
-	oc.Logger.Info().Msg(fmt.Sprintf("Sending broadcastTx with account sequence number %d and fee %s", txf.Sequence(), txf.Fees().String()))
+	oc.Logger.Info().Msg(fmt.Sprintf("Sending broadcastTx with account sequence number %d and fee %s", txf.Sequence(), txBuilder.GetTx().GetFee().String()))
 
 	// broadcast transaction
 	resp, err := clientCtx.BroadcastTx(txBytes)

--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -206,9 +206,8 @@ func (oc OracleClient) BroadcastTx(
 		return nil, err
 	}
 
-	// Calculate the fee for the TX
-	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("akii", math.NewIntFromUint64(80000000000000000))))
-
+	// Calculate the fee for the TX and set the gas limit
+	txf.GasPrices().MulDec(math.LegacyNewDec(int64(oc.GasLimit)))
 	txBuilder.SetGasLimit(oc.GasLimit)
 
 	// Sign the transaction
@@ -223,7 +222,8 @@ func (oc OracleClient) BroadcastTx(
 		return nil, err
 	}
 
-	oc.Logger.Info().Msg(fmt.Sprintf("Sending broadcastTx with account sequence number %d", txf.Sequence()))
+	// Log the transaction details
+	oc.Logger.Info().Msg(fmt.Sprintf("Sending broadcastTx with account sequence number %d and fee %s", txf.Sequence(), txf.Fees().String()))
 
 	// broadcast transaction
 	resp, err := clientCtx.BroadcastTx(txBytes)
@@ -323,7 +323,6 @@ func (oc OracleClient) CreateTxFactory() (tx.Factory, error) {
 		WithTxConfig(clientCtx.TxConfig).
 		WithGasAdjustment(oc.GasAdjustment).
 		WithGasPrices(oc.GasPrices).
-		WithGas(0).
 		WithKeybase(clientCtx.Keyring).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
 		WithSimulateAndExecute(true)


### PR DESCRIPTION
# Description

Fix broken fees:
- It seems that between cosmos v0.45 and v0.50 the fees on transaction builders changed
- This changes the way we apply fees directly on the tx using `gas_price*gas_limit`

This PR also changes the default fee and gas values on the config:
- From `500000akii` to `400000000000akii`
- From `2000000` to `200000` (one less zero)

This passed unrealized on the Devnet configuration because on the devnet the minimum gas may not be configured correctly.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tested on a validator node
